### PR TITLE
Add Swift nullability annotations

### DIFF
--- a/Projection/PRJMapping.h
+++ b/Projection/PRJMapping.h
@@ -37,6 +37,7 @@ Usage:
 */
 
 @interface PRJMapping : NSObject
+NS_ASSUME_NONNULL_BEGIN
 
 /** Returns the PRJRect associated with the given UIView.
 @param key The UIView for which to return the associatedPRJRect.
@@ -60,4 +61,5 @@ instead.
 /// Iterates through all view/rect entries and sets the rect's integralFrame as the view's frame.
 - (void)apply;
 
+NS_ASSUME_NONNULL_END
 @end

--- a/Projection/PRJRect.h
+++ b/Projection/PRJRect.h
@@ -54,6 +54,7 @@ set) or if it doesn't have enough definition to define a value.
 */
 
 @interface PRJRect : NSObject<NSCopying>
+NS_ASSUME_NONNULL_BEGIN
 
 @property(nonatomic, assign) CGFloat left;
 @property(nonatomic, assign) CGFloat right;
@@ -79,4 +80,5 @@ set) or if it doesn't have enough definition to define a value.
 /// YES if exactly two horizontal and two vertical values are set.
 @property(nonatomic, readonly) BOOL isFullyDefined;
 
+NS_ASSUME_NONNULL_END
 @end

--- a/Projection/UIView+PRJConvenience.h
+++ b/Projection/UIView+PRJConvenience.h
@@ -9,7 +9,7 @@
 @class PRJMapping;
 @class PRJRect;
 
-typedef void (^PRJConfigurationBlock)(PRJMapping *mapping, PRJRect *viewBounds);
+typedef void (^PRJConfigurationBlock)(PRJMapping * __nonnull mapping, PRJRect * __nonnull viewBounds);
 
 /** Convenience category for applying layout to a view's children.
 
@@ -45,6 +45,7 @@ The following two examples are equivalent:
 */
 
 @interface UIView (PRJConvenience)
+NS_ASSUME_NONNULL_BEGIN
 
 - (void)prj_applyProjection:(PRJConfigurationBlock)configurationBlock;
 - (void)prj_applyProjectionWithSize:(CGSize)size
@@ -52,4 +53,5 @@ The following two examples are equivalent:
 - (void)prj_applyProjectionWithBounds:(CGRect)bounds
                         configuration:(PRJConfigurationBlock)configurationBlock;
 
+NS_ASSUME_NONNULL_END
 @end


### PR DESCRIPTION
Test Plan: Created a Swift project and used Projection. Project worked and that types were no longer implicitly unwrapped optionals

![image](https://cloud.githubusercontent.com/assets/2266187/7924541/eee411c0-0870-11e5-8c37-76c05dbc0413.png)
