### PR TITLE
Add dependencies to headers

### DIFF
--- a/Projection/PRJMapping.h
+++ b/Projection/PRJMapping.h
@@ -6,6 +6,9 @@
 //  Copyright (c) 2015 Mikey Lintz. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
 //   - document when rounding happens (never! mapping does rounding)
 //   - document quirks in PRJMapping subscription (retains (not copy) key,
 //            creates new key if one doesn't exist on a get)

--- a/Projection/PRJProjection.h
+++ b/Projection/PRJProjection.h
@@ -6,6 +6,9 @@
 //  Copyright (c) 2015 Mikey Lintz. All rights reserved.
 //
 
-#import "PRJMapping.h"
-#import "PRJRect.h"
-#import "UIView+PRJConvenience.h"
+#ifndef _PROJECTION_
+    #define _PROJECTION_
+    #import "PRJMapping.h"
+    #import "PRJRect.h"
+    #import "UIView+PRJConvenience.h"
+#endif /* _PROJECTION_ */

--- a/Projection/PRJRect.h
+++ b/Projection/PRJRect.h
@@ -6,6 +6,9 @@
 //  Copyright (c) 2015 Mikey Lintz. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
 /** A helper class for incrementally defining the frame for a view.
 
 PRJRect will attempt to infer the value of left, right, etc based on what's previously been set.

--- a/Projection/UIView+PRJConvenience.h
+++ b/Projection/UIView+PRJConvenience.h
@@ -6,6 +6,9 @@
 //  Copyright (c) 2015 Mikey Lintz. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
 @class PRJMapping;
 @class PRJRect;
 


### PR DESCRIPTION
Most projects were probably okay because they imported `Foundation` and `UIKit` themselves.
