### PR TITLE
Add more syntax options for applying a projection to a single view without a map

### DIFF
--- a/ManualLayoutDemo/ViewController.m
+++ b/ManualLayoutDemo/ViewController.m
@@ -57,21 +57,47 @@
 - (void)viewWillLayoutSubviews {
   [super viewWillLayoutSubviews];
 
-  [self.view prj_applyProjection:^(PRJMapping *mapping, PRJRect *viewBounds) {
-    mapping[self.cyanView].height = 100;
-    mapping[self.cyanView].width = 100;
-    mapping[self.cyanView].center = viewBounds.center;
-    
-    mapping[self.magentaView].bottomLeft = mapping[self.cyanView].topRight;
-    mapping[self.magentaView].size = mapping[self.cyanView].size;
-    
-    mapping[self.brownView].center = mapping[self.magentaView].center;
-    mapping[self.brownView].height = mapping[self.magentaView].height - 40;
-    mapping[self.brownView].width = mapping[self.brownView].height;
-
-    mapping[self.yellowLayer].center = mapping[self.brownView].center;
-    mapping[self.yellowLayer].size = mapping[self.brownView].size;
+//  [self.view prj_applyProjection:^(PRJMapping *mapping, PRJRect *viewBounds) {
+//    mapping[self.cyanView].height = 100;
+//    mapping[self.cyanView].width = 100;
+//    mapping[self.cyanView].center = viewBounds.center;
+//    
+//    mapping[self.magentaView].bottomLeft = mapping[self.cyanView].topRight;
+//    mapping[self.magentaView].size = mapping[self.cyanView].size;
+//    
+//    mapping[self.brownView].center = mapping[self.magentaView].center;
+//    mapping[self.brownView].height = mapping[self.magentaView].height - 40;
+//    mapping[self.brownView].width = mapping[self.brownView].height;
+//
+//    mapping[self.yellowLayer].center = mapping[self.brownView].center;
+//    mapping[self.yellowLayer].size = mapping[self.brownView].size;
+//  }];
+	
+  [self.cyanView prj_applySingleProjection:^(PRJRect * _Nonnull frame) {
+	frame.height = 100;
+	frame.width = 100;
+	frame.center = self.view.prj_frame.center;
   }];
+
+  [self.magentaView prj_applySingleProjection:^(PRJRect * _Nonnull frame) {
+	frame.bottomLeft = self.cyanView.prj_frame.topRight;
+	frame.size = self.cyanView.prj_frame.size;
+  }];
+	
+  [self.brownView prj_applySingleProjection:^(PRJRect * _Nonnull frame) {
+	frame.center = self.magentaView.prj_frame.center;
+	frame.height = self.magentaView.prj_frame.height - 40;
+	frame.width = frame.height;
+	  
+	// MUST do this using the PRJRect supplied here, because after it is applied, the transform is applied
+	// This changes the frame, and therefore changes our PRJRect if we attempt to ask for it, from the view.
+	// I believe this to be the desired behavior regarding transforms with this syntax.
+	PRJRect* yellowLayerRect = [[PRJRect alloc] init];
+	yellowLayerRect.center = frame.center;
+	yellowLayerRect.size = frame.size;
+	[self.yellowLayer prj_apply:yellowLayerRect];
+  }];
+
 }
 
 @end

--- a/Projection/PRJCategories.m
+++ b/Projection/PRJCategories.m
@@ -12,6 +12,23 @@
 
 @implementation UIView (PRJProjectable)
 
+-(PRJRect *)prj_frame {
+	return [[PRJRect alloc] initWithFrame:self.frame];
+}
+
+-(void)setPrj_frame:(PRJRect *)prj_frame {
+	[self prj_apply:prj_frame];
+}
+
+-(PRJRect *)prj_bounds {
+	return [[PRJRect alloc] initWithFrame:self.bounds];
+}
+
+-(void)setPrj_bounds:(PRJRect *)prj_bounds {
+	PRJRect* frame = [[PRJRect alloc] initWithFrame:[self convertRect:prj_bounds.frame toView:self.superview]];
+	[self prj_apply:frame];
+}
+
 - (void)prj_apply:(PRJRect *)rect {
   CGRect frame = rect.roundedFrame;
   self.bounds = CGRectMake(CGRectGetMinX(self.bounds),
@@ -26,6 +43,23 @@
 @end
 
 @implementation CALayer (PRJProjectable)
+
+-(PRJRect *)prj_frame {
+	return [[PRJRect alloc] initWithFrame:self.frame];
+}
+
+-(void)setPrj_frame:(PRJRect *)prj_frame {
+	[self prj_apply:prj_frame];
+}
+
+-(PRJRect *)prj_bounds {
+	return [[PRJRect alloc] initWithFrame:self.bounds];
+}
+
+-(void)setPrj_bounds:(PRJRect *)prj_bounds {
+	PRJRect* frame = [[PRJRect alloc] initWithFrame:[self convertRect:prj_bounds.frame toLayer:self.superlayer]];
+	[self prj_apply:frame];
+}
 
 - (void)prj_apply:(PRJRect *)rect {
   CGRect frame = rect.roundedFrame;
@@ -42,6 +76,25 @@
 @end
 
 @implementation UIViewController (PRJProjectable)
+
+//These frame and bounds methods are a little weird, but this whole category is a little weird
+
+-(PRJRect *)prj_frame {
+	return [[PRJRect alloc] initWithFrame:self.view.frame];
+}
+
+-(void)setPrj_frame:(PRJRect *)prj_frame {
+	[self prj_apply:prj_frame];
+}
+
+-(PRJRect *)prj_bounds {
+	return [[PRJRect alloc] initWithFrame:self.view.bounds];
+}
+
+-(void)setPrj_bounds:(PRJRect *)prj_bounds {
+	PRJRect* frame = [[PRJRect alloc] initWithFrame:[self.view convertRect:prj_bounds.frame toView:self.view.superview]];
+	[self prj_apply:frame];
+}
 
 - (void)prj_apply:(PRJRect *)rect {
   [self.view prj_apply:rect];

--- a/Projection/PRJCategories.m
+++ b/Projection/PRJCategories.m
@@ -20,15 +20,6 @@
 	[self prj_apply:prj_frame];
 }
 
--(PRJRect *)prj_bounds {
-	return [[PRJRect alloc] initWithFrame:self.bounds];
-}
-
--(void)setPrj_bounds:(PRJRect *)prj_bounds {
-	PRJRect* frame = [[PRJRect alloc] initWithFrame:[self convertRect:prj_bounds.frame toView:self.superview]];
-	[self prj_apply:frame];
-}
-
 - (void)prj_apply:(PRJRect *)rect {
   CGRect frame = rect.roundedFrame;
   self.bounds = CGRectMake(CGRectGetMinX(self.bounds),
@@ -52,15 +43,6 @@
 	[self prj_apply:prj_frame];
 }
 
--(PRJRect *)prj_bounds {
-	return [[PRJRect alloc] initWithFrame:self.bounds];
-}
-
--(void)setPrj_bounds:(PRJRect *)prj_bounds {
-	PRJRect* frame = [[PRJRect alloc] initWithFrame:[self convertRect:prj_bounds.frame toLayer:self.superlayer]];
-	[self prj_apply:frame];
-}
-
 - (void)prj_apply:(PRJRect *)rect {
   CGRect frame = rect.roundedFrame;
   self.bounds = CGRectMake(CGRectGetMinX(self.bounds),
@@ -77,7 +59,7 @@
 
 @implementation UIViewController (PRJProjectable)
 
-//These frame and bounds methods are a little weird, but this whole category is a little weird
+//These frame methods are a little weird, but this whole category is a little weird
 
 -(PRJRect *)prj_frame {
 	return [[PRJRect alloc] initWithFrame:self.view.frame];
@@ -85,15 +67,6 @@
 
 -(void)setPrj_frame:(PRJRect *)prj_frame {
 	[self prj_apply:prj_frame];
-}
-
--(PRJRect *)prj_bounds {
-	return [[PRJRect alloc] initWithFrame:self.view.bounds];
-}
-
--(void)setPrj_bounds:(PRJRect *)prj_bounds {
-	PRJRect* frame = [[PRJRect alloc] initWithFrame:[self.view convertRect:prj_bounds.frame toView:self.view.superview]];
-	[self prj_apply:frame];
 }
 
 - (void)prj_apply:(PRJRect *)rect {

--- a/Projection/PRJMapping.h
+++ b/Projection/PRJMapping.h
@@ -36,6 +36,9 @@ Usage:
 @protocol PRJProjectable <NSObject>
 NS_ASSUME_NONNULL_BEGIN
 
+@property (nonatomic, strong) PRJRect* prj_frame;
+@property (nonatomic, strong) PRJRect* prj_bounds;
+
 - (void)prj_apply:(PRJRect *)rect;
 
 NS_ASSUME_NONNULL_END

--- a/Projection/PRJMapping.h
+++ b/Projection/PRJMapping.h
@@ -37,7 +37,6 @@ Usage:
 NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, strong) PRJRect* prj_frame;
-@property (nonatomic, strong) PRJRect* prj_bounds;
 
 - (void)prj_apply:(PRJRect *)rect;
 

--- a/Projection/PRJRect.h
+++ b/Projection/PRJRect.h
@@ -90,6 +90,8 @@ NS_ASSUME_NONNULL_BEGIN
 + (CGFloat)minFloat;
 + (void)debugSetMinFloat:(CGFloat)minFloat;
 
+- (instancetype)initWithFrame:(CGRect)rect;
+
 - (instancetype)left:(CGFloat)left;
 - (instancetype)right:(CGFloat)right;
 - (instancetype)centerX:(CGFloat)centerX;

--- a/Projection/PRJRect.m
+++ b/Projection/PRJRect.m
@@ -101,6 +101,15 @@ typedef NS_OPTIONS(NSUInteger, PRJMetricType) {
   return self;
 }
 
+- (instancetype)initWithFrame:(CGRect)rect {
+	self = [self init];
+	if (self) {
+		self.topLeft = rect.origin;
+		self.size = rect.size;
+	}
+	return self;
+}
+
 - (NSString *)description {
   NSString *metricFormat = @"%@ = %.2f";
   NSMutableArray *metricDescriptions = [NSMutableArray arrayWithCapacity:4];

--- a/Projection/UIView+PRJConvenience.h
+++ b/Projection/UIView+PRJConvenience.h
@@ -13,6 +13,7 @@
 @class PRJRect;
 
 typedef void (^PRJConfigurationBlock)(PRJMapping * __nonnull mapping, PRJRect * __nonnull viewBounds);
+typedef void (^PRJSingleConfigurationBlock)(PRJRect * __nonnull frame);
 
 /** Convenience category for applying layout to a view's children.
 
@@ -51,6 +52,7 @@ The following two examples are equivalent:
 NS_ASSUME_NONNULL_BEGIN
 
 - (void)prj_applyProjection:(__attribute__((noescape)) PRJConfigurationBlock)configurationBlock;
+- (void)prj_applySingleProjection:(PRJSingleConfigurationBlock)configurationBlock;
 - (void)prj_applyProjectionWithSize:(CGSize)size
                       configuration:(__attribute__((noescape)) PRJConfigurationBlock)configurationBlock;
 - (void)prj_applyProjectionWithBounds:(CGRect)bounds

--- a/Projection/UIView+PRJConvenience.m
+++ b/Projection/UIView+PRJConvenience.m
@@ -10,11 +10,20 @@
 
 #import "PRJMapping.h"
 #import "PRJRect.h"
+#import "PRJCategories.h"
 
 @implementation UIView (PRJConvenience)
 
 - (void)prj_applyProjection:(PRJConfigurationBlock)configurationBlock {
   [self prj_applyProjectionWithBounds:self.bounds configuration:configurationBlock];
+}
+
+- (void)prj_applySingleProjection:(PRJSingleConfigurationBlock)configurationBlock {
+	[self prj_applyProjectionWithBounds:self.bounds configuration:^(PRJMapping * _Nonnull mapping, PRJRect * _Nonnull viewBounds) {
+		PRJRect* rect = [[PRJRect alloc] init];
+		configurationBlock(rect);
+		mapping[self] = rect;
+	}];
 }
 
 - (void)prj_applyProjectionWithSize:(CGSize)size


### PR DESCRIPTION
### Reasoning
I really like the library, but the `PRJMapping` syntax didn't sit right with me, compared to what I've used in the past with auto layout.  So I woke up this morning and had an idea to implement that syntax, after I had explored the library last night.

### How?
By adding a `prj_frame` property to `PRJProjcectable`, we allow for interaction with a projectable's projection via the projectable itself.  It allows for us to actually just set the projection for a single object.

Then we can call `prj_applySingleProjection`, which supplies a `PRJRect*` to the user, and interact with other `PRJProjectable` objects via their `prj_frame`.  We take the `PRJRect*` afterwards and apply it with a mapping.  However, it might be faster/better to not use `PRJMapping` at all.  That could be changed, but it works for now.

Right now this syntax is only implemented for `UIView`, but it could be implemented for others, too.

### Concerns
I worry slightly about performance hits from using this syntax over a mapping.  I'm going between `CGRect` and `PRJRect` a lot with this implementation and there should probably be a cached value for `prj_frame` that way we don't always have to make a new one.  Then again, these objects are straightforward and small, so maybe it isn't such a big deal.

Because of how transforms alter the `frame` property of objects, it means `prj_frame` will also be altered.  This, to me, is the desired effect for as long as it is the desired effect for `frame`.

I should have split this into more, smaller commits.

### Misc
Currently commented out `PRJMapping` style syntax in demo to show equivalent syntax in  my proposed fashion.  This should be changed.

I also added `initWithFrame:` functionality to `PRJRect` which I felt was missing.